### PR TITLE
Wrong parameter in call to GPNF_Session class constructor

### DIFF
--- a/class-gp-nested-forms.php
+++ b/class-gp-nested-forms.php
@@ -957,7 +957,7 @@ class GP_Nested_Forms extends GP_Plugin {
 
 	public function delete_child_entries_on_save_and_continue( $form ) {
 		if ( rgpost( 'gform_save' ) ) {
-			$session = new GPNF_Session( $form );
+			$session = new GPNF_Session( $form['id'] );
 			$session->delete_cookie();
 		}
 	}


### PR DESCRIPTION
Fixed parameter in call to GPNF_Session class constructor in delete_child_entries_on_save_and_continue function. Constructor expects string with form id, while we were passing form array. 

Did the following tests to verify solution:
1. Child entries are get cleared after clicking on 'Save and Continue Later' - PASSED
2. There are no php errors displayed when clicking on 'Save and Continue Later' - PASSED
3. Link with form version is generated, containing saved entries and available for submit - PASSED